### PR TITLE
Set server state to STARTED; jai version updates

### DIFF
--- a/examples/example.jai
+++ b/examples/example.jai
@@ -17,37 +17,37 @@ main :: () {
     }
 
     server: Server;
-    server.verbose = args.verbose;
+    server.verbose = ifx args.verbose then .NORMAL else .NONE;
 
     {
         success := add_route(*server, .GET, "/", (request: *Request, parameters: *Request_Parameters()) {
             log("Got root request!");
             respond("pretend this is index.html", content_type = "text/html");
-        });
+        }, auth = .OFF);
         success &= add_route(*server, .GET, "/ping", (request: *Request, parameters: *Request_Parameters()) {
             respond("pong", content_type = "text/plain");
-        });
+        }, auth = .OFF);
         success &= add_route(*server, .POST, "/", (request: *Request, parameters: *Request_Parameters()) {
             log("Got root POST!");
             respond("Something was wrong with your post", 422);
-        });
+        }, auth = .OFF);
 
         success &= add_route(*server, .GET, "/long/path/but/no/params", (request: *Request, parameters: *Request_Parameters()) {
             log("Got long path request!");
             respond("");
-        });
+        }, auth = .OFF);
         success &= add_route(*server, .GET, "/{prefix}/long/path/but/no/more/params", (request: *Request, parameters: *Request_Parameters(struct {prefix: string;})) {
             log("Got long path request with prefix \"%\": %!", parameters.path.prefix, request.url);
             respond("");
-        });
+        }, auth = .OFF);
         success &= add_route(*server, .GET, "/{path}", (request: *Request, parameters: *Request_Parameters(struct {path: string;})) {
             log("Got path request: %", request.url);
             respond("");
-        });
+        }, auth = .OFF);
         success &= add_route(*server, .GET, "/ping/{path*}", (request: *Request, parameters: *Request_Parameters(struct {path: string;})) {
             log("Got ping request with wildcard path \"%\": %", parameters.path.path, request.url);
             respond("");
-        });
+        }, auth = .OFF);
 
         {
             Path_Params :: struct {
@@ -66,7 +66,7 @@ main :: () {
                 log("Got members request with parameters: %", <<parameters);
                 context.print_style.default_format_struct.use_long_form_if_more_than_this_many_members = 5;
                 // @ToDo: reply
-            });
+            }, auth = .OFF);
         }
         if !success exit(1);
 

--- a/module.jai
+++ b/module.jai
@@ -381,6 +381,7 @@ start :: (server: *Server, port: u16, num_threads: s32 = 10) -> bool {
 
     init_request_thread_group(server, num_threads);
 
+    server.state = .STARTED;
     return true;
 }
 

--- a/module.jai
+++ b/module.jai
@@ -535,7 +535,7 @@ begin_response :: (builder: *String_Builder, content_length: s64, status_code: S
         }
 
         print_to_builder(builder, "%: %\r\n", it.name, it.value);
-        lower_name := to_lower_copy_new(it.name,, temp);
+        lower_name := to_lower_copy(it.name,, temp);
         if lower_name == {
             case "content-length"; #through;
             case "transfer-encoding";
@@ -1670,7 +1670,7 @@ parse_value :: (dest: *void, info: *Type_Info, to_parse: string) -> success: boo
             return true, "";
         // case .FLOAT;
         case .BOOL;
-            lower_value := to_lower_copy_new(to_parse,, temp);
+            lower_value := to_lower_copy(to_parse,, temp);
             bool_pointer := cast(*bool) dest;
             if lower_value == {
                 case "true"; #through;
@@ -1695,7 +1695,7 @@ parse_value :: (dest: *void, info: *Type_Info, to_parse: string) -> success: boo
         case .ENUM;
             info_enum := cast(*Type_Info_Enum) info;
             // @ToDo: Allow other normalization
-            normalized_value := to_upper_copy_new(to_parse,, temp);
+            normalized_value := to_upper_copy(to_parse,, temp);
             for name: info_enum.names {
                 if name == normalized_value {
                     int_value := info_enum.values[it_index];
@@ -1708,7 +1708,7 @@ parse_value :: (dest: *void, info: *Type_Info, to_parse: string) -> success: boo
             builder: String_Builder;
             append(*builder, "Invalid value. Allowed: ");
             for name: info_enum.names {
-                normalized_name := to_lower_copy_new(name,, temp);
+                normalized_name := to_lower_copy(name,, temp);
                 if it_index append(*builder, ", ");
                 append(*builder, normalized_name);
             }

--- a/routes.jai
+++ b/routes.jai
@@ -251,7 +251,7 @@ analyze_path :: (path: string) -> success: bool, parameters: [] string = .[], se
 
             array_add(*parameters, parameter);
         } else {
-            segment.literal = to_lower_copy_new(part);
+            segment.literal = to_lower_copy(part);
         }
         array_add(*segments, segment);
     }


### PR DESCRIPTION
Hey hey -- 

I made a few updates while getting this to work, and thought I'd make a PR in case they were helpful.

The biggest one is setting the server state to `.STARTED` when `start()` succeeds - I noticed the server never transitioned out of the `.DEFAULT`. state.

The others were just minor updates to `example.jai` to get it to compile correctly, and fixing a few deprecated string functions for jai 0.2.006. I'd already committed these to my `master` which is why they're included but I'm happy to separate those out. 