### PR TITLE
Fix content-length logic

### DIFF
--- a/module.jai
+++ b/module.jai
@@ -548,6 +548,10 @@ begin_response :: (builder: *String_Builder, content_length: s64, status_code: S
         }
     }
 
+    if size_header_needs_to_be_added {
+        print_to_builder(builder, "content-length: %\r\n", content_length);
+    }
+
     if request.is_event_stream || (request.http_version == HTTP_1_0 && client.remove_after_request == false) {
         append(builder, "connection: keep-alive\r\n");
     } else if request.http_version == HTTP_1_1 && client.remove_after_request == true {


### PR DESCRIPTION
Accidentally removed this in my last PR, noticed while testing the examples.

Also wanted to note that I commented out the line that asserts against non-GET requests, in case you want that there still: https://github.com/rluba/hyperserve/blob/5bb571d4127fd4ac4e7b2d667286e105e971b729/module.jai#L1436